### PR TITLE
Fix example code for inline image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -145,7 +145,7 @@ Connection with user authentication::
 ;; => {:result :success, :code 250, :message "250 OK\n"}
 ----
 
-==== Inline image
+==== Inline image (Multipart/related)
 
 [source,clojure]
 ----
@@ -158,6 +158,7 @@ Connection with user authentication::
     (tarayo/send! conn {:from "alice@example.com"
                         :to "bob@example.com"
                         :subject "hello"
+                        :multipart "related"
                         :body [{:content (str "<img src=\"cid:" content-id "\" /> world") :content-type "text/html"}
                                ;; containing id will be handled as "inline attachment file"
                                {:content (io/file "test/resources/image.png") :id content-id}]})))


### PR DESCRIPTION
The default Content-Type `mixed` can some some issues if the image is supposed to be displayed in the email.
For example Mozilla Thunderbird will not show an image unless Content-Type is set to  `related`.
Some other web mail tool I am using did not care and displayed the image nonetheless.

https://en.wikipedia.org/wiki/MIME#related

> A multipart/related is used to indicate that each message part is a component of an aggregate whole. It is for compound objects consisting of several inter-related components – proper display cannot be achieved by individually displaying the constituent parts. The message consists of a root part (by default, the first) which reference other parts inline, which may in turn reference other parts. Message parts are commonly referenced by Content-ID. The syntax of a reference is unspecified and is instead dictated by the encoding or protocol used in the part.

> One common usage of this subtype is to send a web page complete with images in a single message. The root part would contain the [HTML](https://en.wikipedia.org/wiki/HTML) document, and use image tags to reference images stored in the latter parts.