### PR TITLE
Develop

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -6,20 +6,22 @@ jobs:
   clj_style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: 0918nobita/setup-cljstyle@v0.5.2
+      - uses: actions/checkout@v4
+      - uses: DeLaGuardo/setup-clojure@master
         with:
-          cljstyle-version: 0.15.0
+          cljstyle: latest
       - run: cljstyle check --report -v
 
   clj_kondo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: DeLaGuardo/setup-clj-kondo@master
+      - uses: actions/checkout@v4
+      - uses: DeLaGuardo/setup-clojure@master
         with:
-          version: '2021.10.19'
+          clj-kondo: latest
       - run: clj-kondo --lint src:test:integration
+
+
 
   test:
     needs: [clj_style, clj_kondo]
@@ -32,9 +34,9 @@ jobs:
           - 8025:8025
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '8'
@@ -43,7 +45,7 @@ jobs:
 
       - uses: DeLaGuardo/setup-clojure@master
         with:
-          lein: '2.9.7'
+          lein: '2.10.0'
 
       - name: Show versions
         run: |

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ install:
 test:
 	lein test-all
 
+.PHONY: test-integration
+test-integration:
+	lein test-integration
+
 .PHONY: outdated
 outdated:
 	lein antq

--- a/README.adoc
+++ b/README.adoc
@@ -216,7 +216,7 @@ Example using https://github.com/bguthrie/shrubbery[shrubbery].
 
 == License
 
-Copyright 2020-2021 Toyokumo,Inc.
+Copyright 2020-2023 Toyokumo,Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  mailhog:
+    image: mailhog/mailhog:v1.0.0
+    ports:
+      - "1025:1025"
+      - "8025:8025"

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
-  :dependencies [[camel-snake-kebab "0.4.2"]
+  :dependencies [[camel-snake-kebab "0.4.3"]
                  [com.sun.mail/jakarta.mail "2.0.1"]
                  [commons-codec "1.15"]
                  [jakarta.mail/jakarta.mail-api "2.0.1"]

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
          :global-vars {*warn-on-reflection* true}}
 
    :it {:dependencies [[org.clojure/data.json "2.4.0"]
-                       [http-kit "2.5.3"]]
+                       [http-kit "2.7.0"]]
         :test-paths ["integration/test"]}
 
    :antq {:dependencies [[com.github.liquidz/antq "RELEASE"]]}}

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,8 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :dependencies [[camel-snake-kebab "0.4.3"]
-                 [com.sun.mail/jakarta.mail "2.0.1"]
                  [jakarta.mail/jakarta.mail-api "2.0.1"]
+                 [org.eclipse.angus/angus-mail "2.0.2"]
                  [commons-codec "1.16.0"]
                  [nano-id "1.0.0"]
                  [org.apache.tika/tika-core "2.1.0"]]

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,8 @@
 
   :dependencies [[camel-snake-kebab "0.4.3"]
                  [com.sun.mail/jakarta.mail "2.0.1"]
-                 [commons-codec "1.15"]
                  [jakarta.mail/jakarta.mail-api "2.0.1"]
+                 [commons-codec "1.16.0"]
                  [nano-id "1.0.0"]
                  [org.apache.tika/tika-core "2.1.0"]]
 

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :dependencies [[camel-snake-kebab "0.4.3"]
-                 [jakarta.mail/jakarta.mail-api "2.0.1"]
                  [org.eclipse.angus/angus-mail "2.0.2"]
                  [commons-codec "1.16.0"]
+                 [jakarta.mail/jakarta.mail-api "2.1.2"]
                  [nano-id "1.0.0"]
                  [org.apache.tika/tika-core "2.1.0"]]
 

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
    :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
 
-   :dev {:dependencies [[org.clojure/clojure "1.10.3"]
+   :dev {:dependencies [[org.clojure/clojure "1.11.1"]
                         [com.github.kirviq/dumbster "1.7.1"]
                         [testdoc "1.4.1"]
                         ;; for stubbing
@@ -32,7 +32,7 @@
 
    :antq {:dependencies [[com.github.liquidz/antq "RELEASE"]]}}
   :aliases
-  {"test-all" ["with-profile" "1.8,dev:1.9,dev:1.10,dev" "test"]
+  {"test-all" ["with-profile" "1.8,dev:1.9,dev:1.10,dev:dev" "test"]
    "test-integration" ["with-profile" "1.9,dev,it:1.10,dev,it" "test"]
    "antq" ["with-profile" "+antq" "run" "-m" "antq.core"]}
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [commons-codec "1.16.0"]
                  [jakarta.mail/jakarta.mail-api "2.1.2"]
                  [nano-id "1.0.0"]
-                 [org.apache.tika/tika-core "2.1.0"]]
+                 [org.apache.tika/tika-core "2.9.0"]]
 
   :profiles
   {:1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
    "test-integration" ["with-profile" "1.9,dev,it:1.10,dev,it" "test"]
    "antq" ["with-profile" "+antq" "run" "-m" "antq.core"]}
 
-  :plugins [[lein-cloverage "1.2.2"]]
+  :plugins [[lein-cloverage "1.2.4"]]
   :cloverage {:ns-exclude-regex [#"benchmark"]}
 
   :release-tasks [["vcs" "assert-committed"]

--- a/src/tarayo/core.clj
+++ b/src/tarayo/core.clj
@@ -75,8 +75,7 @@
            :else 25)
    :auth (some? user)})
 
-(defn ^tarayo.core.ISMTPConnection
-  connect
+(defn connect
   "Connect to the specified SMTP server.
   If the connection is successful, an open `SMTPConnection` is returned.
 
@@ -89,8 +88,8 @@
     * :starttls.enable
 
   For more information, please see https://jakarta.ee/specifications/mail/1.6/apidocs/com/sun/mail/smtp/package-summary.html"
-  ([] (connect {}))
-  ([smtp-server]
+  (^tarayo.core.ISMTPConnection [] (connect {}))
+  (^tarayo.core.ISMTPConnection [smtp-server]
    (let [smtp-server (merge (get-defaults smtp-server)
                             smtp-server)
          sess (session/make-session smtp-server)]

--- a/src/tarayo/mail/mime.clj
+++ b/src/tarayo/mail/mime.clj
@@ -19,7 +19,8 @@
   (->> (io/resource "VERSION") slurp str/trim
        (str "tarayo/")))
 
-(defn ^MimeMessage make-message
+(defn make-message
+  ^MimeMessage
   [^Session session message]
   (let [{:keys [charset content-type reply-to cc bcc body multipart]} message
         charset (or charset constant/default-charset)

--- a/src/tarayo/mail/mime/address.clj
+++ b/src/tarayo/mail/mime/address.clj
@@ -3,8 +3,8 @@
    (jakarta.mail.internet
     InternetAddress)))
 
-(defn ^InternetAddress
-  make-address
+(defn make-address
+  ^InternetAddress
   [addr charset]
   (let [^InternetAddress addr (cond-> addr
                                 (not (instance? InternetAddress addr))

--- a/src/tarayo/mail/mime/id.clj
+++ b/src/tarayo/mail/mime/id.clj
@@ -7,7 +7,8 @@
    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
    16))
 
-(defn ^String get-random
+(defn get-random
+  ^String
   []
   (let [hostname (.getHostName (java.net.InetAddress/getLocalHost))]
     (format "<%s.%s@%s>" (generate-id) (.getTime (java.util.Date.)) (str "tarayo." hostname))))

--- a/src/tarayo/mail/mime/message.clj
+++ b/src/tarayo/mail/mime/message.clj
@@ -60,7 +60,8 @@
 (defn add-headers
   [^MimeMessage msg headers]
   (doseq [[k v] headers]
-    (.addHeader msg (cond-> k (keyword? k) name) v)))
+    (when (string? v)
+      (.addHeader msg (cond-> k (keyword? k) name) v))))
 
 (defn set-content
   ([^MimeMessage msg ^Multipart multipart]

--- a/src/tarayo/mail/mime/message.clj
+++ b/src/tarayo/mail/mime/message.clj
@@ -11,7 +11,8 @@
     MimeMessage)
    java.util.Date))
 
-(defn ^MimeMessage make-message
+(defn make-message
+  ^MimeMessage
   [^Session session message]
   (proxy [MimeMessage] [^Session session]
     (updateMessageID

--- a/src/tarayo/mail/mime/multipart.clj
+++ b/src/tarayo/mail/mime/multipart.clj
@@ -10,7 +10,8 @@
   (doseq [part parts]
     (.addBodyPart multipart (body/make-bodypart part charset))))
 
-(defn ^MimeMultipart make-multipart
+(defn make-multipart
+  ^MimeMultipart
   [^String multipart-type parts charset]
   (doto (MimeMultipart. multipart-type)
     (add-body-parts parts charset)))

--- a/src/tarayo/mail/mime/multipart/body.clj
+++ b/src/tarayo/mail/mime/multipart/body.clj
@@ -23,13 +23,15 @@
   [^URL url]
   (.detect mime-detector url))
 
-(defn- ^String ensure-string
+(defn- ensure-string
+  ^String
   [x]
   (if (keyword? x)
     (str (.sym ^clojure.lang.Keyword x))
     x))
 
-(defn- ^URL ensure-url
+(defn- ensure-url
+  ^URL
   [x]
   (try
     (io/as-url x)
@@ -54,7 +56,8 @@
       (URLDecoder/decode charset)
       (MimeUtility/encodeText charset nil)))
 
-(defn- ^MimeBodyPart make-attachment-bodypart-by-url
+(defn- make-attachment-bodypart-by-url
+  ^MimeBodyPart
   [part charset]
   (let [{:keys [content filename]} part
         url (ensure-url content)]
@@ -63,7 +66,8 @@
       (.setFileName (or filename (extract-file-name url charset)))
       (.setHeader "Content-Type" (get part :content-type (detect-mime-type url))))))
 
-(defn- ^MimeBodyPart make-attachment-bodypart-by-byte-array
+(defn- make-attachment-bodypart-by-byte-array
+  ^MimeBodyPart
   [part]
   (assert (contains? part :content-type) ":content-type is required for byte array content.")
   (assert (contains? part :filename) ":filename is required for byte array content.")
@@ -88,7 +92,8 @@
       (cond-> id (.setContentID (str "<" id ">")))
       (cond-> content-encoding (.setHeader "Content-Transfer-Encoding" content-encoding)))))
 
-(defn ^MimeBodyPart make-bodypart
+(defn make-bodypart
+  ^MimeBodyPart
   [part charset]
   (let [string-content? (-> part :content string?)
         has-id? (contains? part :id)]

--- a/src/tarayo/mail/mime/multipart/data_source.clj
+++ b/src/tarayo/mail/mime/multipart/data_source.clj
@@ -4,11 +4,11 @@
   (:import
    jakarta.activation.DataSource))
 
-(defn ^DataSource byte-array-data-source
+(defn byte-array-data-source
   "Return jakarta.activation.DataSource instance by byte array."
-  ([^"[B" buf]
+  (^DataSource [^"[B" buf]
    (byte-array-data-source buf "application/octet-stream"))
-  ([^"[B" buf ^String content-type]
+  (^DataSource [^"[B" buf ^String content-type]
    (proxy [DataSource] []
      (getInputStream []
        (io/input-stream buf))

--- a/src/tarayo/mail/session.clj
+++ b/src/tarayo/mail/session.clj
@@ -35,10 +35,10 @@
       (.put props k v))
     props))
 
-(defn ^Session make-session
+(defn make-session
   "Create `jakarta.mail.Session` instance and return it."
-  ([] (make-session {}))
-  ([smtp-server]
+  (^Session [] (make-session {}))
+  (^Session [smtp-server]
    (let [props (session-properties smtp-server)]
      (doto (Session/getInstance props)
        (.setDebug (get smtp-server :debug false))))))

--- a/src/tarayo/mail/transport.clj
+++ b/src/tarayo/mail/transport.clj
@@ -6,14 +6,16 @@
    (jakarta.mail.internet
     MimeMessage)))
 
-(defn- ^String get-protocol
+(defn- get-protocol
+  ^String
   [^Session session]
   ;; c.f. https://jakarta.ee/specifications/mail/1.6/apidocs/com/sun/mail/smtp/package-summary.html
   (if (= "true" (.getProperty session "mail.smtp.ssl.enable"))
     "smtps"
     "smtp"))
 
-(defn ^SMTPTransport make-transport
+(defn make-transport
+  ^SMTPTransport
   [^Session session]
   (.getTransport session (get-protocol session)))
 

--- a/src/tarayo/mail/transport.clj
+++ b/src/tarayo/mail/transport.clj
@@ -1,10 +1,10 @@
 (ns tarayo.mail.transport
   (:import
-   (com.sun.mail.smtp
-    SMTPTransport)
    jakarta.mail.Session
    (jakarta.mail.internet
-    MimeMessage)))
+    MimeMessage)
+   (org.eclipse.angus.mail.smtp
+    SMTPTransport)))
 
 (defn- get-protocol
   ^String

--- a/test/tarayo/core_test.clj
+++ b/test/tarayo/core_test.clj
@@ -8,9 +8,9 @@
    [tarayo.test-helper :as h]
    [testdoc.core])
   (:import
-   (com.sun.mail.smtp
-    SMTPTransport)
-   jakarta.mail.Session))
+   jakarta.mail.Session
+   (org.eclipse.angus.mail.smtp
+    SMTPTransport)))
 
 (t/deftest README-test
   (with-redefs [transport/make-transport (constantly (h/test-transport))]

--- a/test/tarayo/mail/mime/message_test.clj
+++ b/test/tarayo/mail/mime/message_test.clj
@@ -80,7 +80,15 @@
 (t/deftest add-headers-test
   (let [msg (gen-test-message)]
     (t/is (= ["Bar"] (seq (.getHeader msg "Foo"))))
-    (t/is (= ["Baz"] (seq (.getHeader msg "Bar"))))))
+    (t/is (= ["Baz"] (seq (.getHeader msg "Bar")))))
+
+  (t/testing "not string values"
+    (let [{:keys [session]} (h/test-connection)
+          headers {"num" 1
+                   "fn" (constantly "foo")}
+          msg (doto (sut/make-message session {})
+                (sut/add-headers headers))]
+      (t/is (every? #(nil? (.getHeader msg %)) (keys headers))))))
 
 (t/deftest set-content-test
   (t/testing "multipart"

--- a/test/tarayo/mail/mime/message_test.clj
+++ b/test/tarayo/mail/mime/message_test.clj
@@ -28,7 +28,8 @@
         (.saveChanges msg)
         (t/is (= "foo" (.getMessageID msg)))))))
 
-(defn- ^MimeMessage gen-test-message
+(defn- gen-test-message
+  ^MimeMessage
   []
   (let [{:keys [session]} (h/test-connection)
         ^Calendar cal (doto (Calendar/getInstance)

--- a/test/tarayo/mail/transport_test.clj
+++ b/test/tarayo/mail/transport_test.clj
@@ -6,7 +6,7 @@
    [tarayo.mail.transport :as sut]
    [tarayo.test-helper :as h])
   (:import
-   (com.sun.mail.smtp
+   (org.eclipse.angus.mail.smtp
     SMTPSSLTransport
     SMTPTransport)))
 

--- a/test/tarayo/test_helper.clj
+++ b/test/tarayo/test_helper.clj
@@ -61,7 +61,8 @@
     (tarayo-user-agent?  (first x))
     (some?  (re-seq #"^tarayo/.+$" x))))
 
-(defn ^SMTPTransport test-transport
+(defn test-transport
+  ^SMTPTransport
   []
   (proxy [SMTPTransport] [(session/make-session) (jakarta.mail.URLName. "localhost")]
     (connect

--- a/test/tarayo/test_helper.clj
+++ b/test/tarayo/test_helper.clj
@@ -5,7 +5,7 @@
    (com.dumbster.smtp
     SimpleSmtpServer
     SmtpMessage)
-   (com.sun.mail.smtp
+   (org.eclipse.angus.mail.smtp
     SMTPTransport)))
 
 (defrecord TestConnection


### PR DESCRIPTION
* Fixes #17 
* Bumps outdated libraries
  * `com.sun.mail/jakarta.mail` moves to `org.eclipse.angus/angus-mail`
    * Jakarta Mail implementation moves to Eclipse Angus
      * https://jakartaee.github.io/mail-api/
      * https://eclipse-ee4j.github.io/angus-mail/
* Fixes clj-kondo warnings